### PR TITLE
Set sensitive fields as credentials, defer client init

### DIFF
--- a/cosmos-r2.html
+++ b/cosmos-r2.html
@@ -4,10 +4,12 @@
       color: "#E9967A",
       defaults: {
         name: { value: "" },
-        uri: { value: "", required: true },
-        key: { value: "", required: true },
         databaseId: { value: "", required: true },
         containerId: { value: "", required: true },
+      },
+      credentials: {        
+        uri: { type: "text", required: true},
+        key: { type: "password", required: true},
       },
       inputs: 1,
       outputs: 1,
@@ -29,7 +31,7 @@
     </div>
     <div class="form-row">
       <label for="node-input-key"><i class="icon-key"></i> Key</label>
-      <input type="text" id="node-input-key" placeholder="Key">
+      <input type="password" id="node-input-key" placeholder="Key">
     </div>
     <div class="form-row">
       <label for="node-input-databaseId"><i class="icon-database"></i> Database ID</label>

--- a/cosmos-r2.js
+++ b/cosmos-r2.js
@@ -5,8 +5,8 @@ module.exports = function (RED) {
     RED.nodes.createNode(this, config);
     const node = this;
 
-    const uri = config.uri;
-    const key = config.key;
+    const uri = this.credentials.uri;
+    const key = this.credentials.key;
     const databaseId = config.databaseId;
     const containerId = config.containerId;
 
@@ -63,6 +63,11 @@ module.exports = function (RED) {
     });
   }
 
-  RED.nodes.registerType("cosmos-r2", CosmosR2Node);
+  RED.nodes.registerType("cosmos-r2", CosmosR2Node,{
+    credentials: {
+      uri: { type:"text" },
+      key: { type:"password" }
+    }
+  });
 };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "node-red-cosmos-r2",
-    "version": "1.0.2",
+    "version": "1.0.3",
     "description": "A Node-RED custom node that connects to a Cosmos DB and performs create, update, read, delete, and upsert operations.",
     "main": "cosmos-r2.js",
     "keywords": [


### PR DESCRIPTION
### Updates
- Set URI and Key values as credentials. This means they are handled within flows_cred.json instead of the main flow file, and can properly be encrypted and omitted from a repo.
- Moved Cosmos client initialization behind input flow instead of on node initialization. This prevents the client from attempting to be initialized with potentially blank fields before the node is properly configured and throwing an error (e.g., `TypeError [ERR_INVALID_URL]`.
- Added additional field checks before client initialization.

### Testing
[flows.json](https://github.com/user-attachments/files/21972724/flows.json)

<img width="1493" height="560" alt="image" src="https://github.com/user-attachments/assets/59e1f7c3-54a6-4e0c-853b-a9190e84bca3" />
